### PR TITLE
Restrict `IntoStatic` to be idempotent.

### DIFF
--- a/changes/2.change.md
+++ b/changes/2.change.md
@@ -1,0 +1,2 @@
+Restricted `IntoStatic` to be idempotent.
+The additional `IntoStatic<Static = Self::Static>` bound to `Static` of `IntoStatic` was added.

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -32,7 +32,7 @@ use alloc::{
 /// Upgrading to `'static` lifetimes.
 pub trait IntoStatic {
     /// The type with `'static` lifetimes.
-    type Static: 'static;
+    type Static: IntoStatic<Static = Self::Static> + 'static;
 
     /// Upgrades [`Self`] to [`Self::Static`].
     fn into_static(self) -> Self::Static;


### PR DESCRIPTION
This PR adds the `IntoStatic<Static = Self::Static>` bound to the `Static` associated type in `IntoStatic`.
Closes #1.